### PR TITLE
TALK SUPPLEMENT: Make fibonacci benchmark run the same case as zkvm-perf

### DIFF
--- a/benchmarks/methods/guest/src/bin/fibonacci.rs
+++ b/benchmarks/methods/guest/src/bin/fibonacci.rs
@@ -21,6 +21,13 @@ fn main() {
     env::commit(&answer);
 }
 
-fn fibonacci(n: u32) -> u64 {
-    Matrix2::new(1, 1, 1, 0).pow(n - 1)[(0, 0)]
+fn fibonacci(n: u32) -> u32 {
+    let mut a: u32 = 0;
+    let mut b: u32 = 1;
+    for _ in 0..n {
+        let sum = (a + b) % 7919; // Mod to avoid overflow
+        a = b;
+        b = sum;
+    }
+    b
 }

--- a/benchmarks/src/benches/fibonacci.rs
+++ b/benchmarks/src/benches/fibonacci.rs
@@ -18,7 +18,7 @@ use crate::Job;
 
 pub fn new_jobs() -> Vec<Job> {
     let mut jobs = Vec::new();
-    for iterations in [10u32, 50, 90] {
+    for iterations in [3000000u32,] {
         jobs.push(Job::new(
             format!("fibonacci-{iterations}"),
             risc0_benchmark_methods::FIBONACCI_ELF,

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -96,17 +96,17 @@ pub struct Job {
     name: String,
     elf: Vec<u8>,
     input: Vec<u32>,
-    image_id: Digest,
+    // image_id: Digest,
     size: usize,
 }
 
 impl Job {
-    fn new(name: String, elf: &[u8], image_id: Digest, input: Vec<u32>, size: usize) -> Self {
+    fn new(name: String, elf: &[u8], _image_id: Digest, input: Vec<u32>, size: usize) -> Self {
         Self {
             name,
             elf: elf.to_vec(),
             input,
-            image_id,
+            // image_id,
             size,
         }
     }
@@ -114,6 +114,7 @@ impl Job {
     fn exec_compute(&self) -> (Session, Duration) {
         let env = ExecutorEnv::builder()
             .write_slice(&self.input)
+            .segment_limit_po2(21)
             .build()
             .unwrap();
         let mut exec = ExecutorImpl::from_elf(env, &self.elf).unwrap();
@@ -130,22 +131,24 @@ impl Job {
 
         metrics.total_cycles = session.total_cycles;
         metrics.user_cycles = session.user_cycles;
+        println!("user_cycles {}", session.user_cycles);
         metrics.exec_duration = duration;
 
-        let prover = get_prover_server(&ProverOpts::succinct()).unwrap();
+        // let prover = get_prover_server(&ProverOpts::succinct()).unwrap();
+        let prover = get_prover_server(&ProverOpts::default()).unwrap();
         let ctx = VerifierContext::default();
 
         let start = Instant::now();
-        let receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
+        let _receipt = prover.prove_session(&ctx, &session).unwrap().receipt;
         metrics.proof_duration = start.elapsed();
 
         metrics.total_duration = metrics.exec_duration + metrics.proof_duration;
         metrics.speed = self.size as f32 / metrics.total_duration.as_secs_f32();
-        metrics.output_bytes = receipt.journal.bytes.len();
-        metrics.proof_bytes = receipt.inner.succinct().unwrap().seal_size();
+        metrics.output_bytes = 0; // receipt.journal.bytes.len();
+        metrics.proof_bytes = 0; // receipt.inner.succinct().unwrap().seal_size();
 
         let start = Instant::now();
-        receipt.verify(self.image_id).unwrap();
+        // receipt.verify(self.image_id).unwrap();
         metrics.verify_duration = start.elapsed();
 
         metrics

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -135,6 +135,7 @@ impl Job {
         metrics.exec_duration = duration;
 
         // let prover = get_prover_server(&ProverOpts::succinct()).unwrap();
+        // Time pipelined witness gen + proving, without recursion
         let prover = get_prover_server(&ProverOpts::default()).unwrap();
         let ctx = VerifierContext::default();
 


### PR DESCRIPTION
This PR is a small diff that updates v1.2.4's Fibonacci benchmark to roughly match [zkvm-perf](https://github.com/succinctlabs/zkvm-perf)'s `fibonacci40m` case and report `proof_duration` analogous to zkvm-perf's `core_prove_duration`.
Specifically, the PR
- runs the same inner loop as zkvm-perf's `fibonacci40m` case for the same number of loop iterations,
- uses the max allowable segment size on an NVIDIA L4 GPU (2^21), and
- times just pipelined witness gen + segment proving rather than witness gen + proving + recursion.

Run via
```
cd benchmarks
cargo run --release -F cuda fibonacci
```

As a sanity check, I profiled the code with [Nsight Systems](https://developer.nvidia.com/nsight-systems), and as far as I can tell `proof_duration` reported with this diff does correspond to pipelined witness gen + segment proving.

To their credit, Risc0's original "Matrix2::new(1, 1, 1, 0).pow(n - 1)[(0, 0)]` syntax greatly reduces the `user_cycles` count for the Fibonacci loop, so whatever it does under the hood is a good thing overall.
But the goal here is to run roughly the same raw cycles as zkvm-perf, and compare.
